### PR TITLE
Added support for more than one Bitlocker key per volume

### DIFF
--- a/Invoke-EscrowBitlockerToAAD.ps1
+++ b/Invoke-EscrowBitlockerToAAD.ps1
@@ -56,14 +56,20 @@ function Get-KeyProtectorId ($BitlockerDrive) {
 
 function Invoke-BitlockerEscrow ($BitlockerDrive,$BitlockerKey) {
     #Escrow the key into Azure AD
-    try {
-        BackupToAAD-BitLockerKeyProtector -MountPoint $BitlockerDrive -KeyProtectorId $BitlockerKey -ErrorAction SilentlyContinue
-        Write-Output "Attempted to escrow key in Azure AD - Please verify manually!"
-        exit 0
-    } catch {
-        Write-Error "This should never have happend? Debug me!"
-        exit 1
+
+    foreach ($Key in $BitlockerKey) {
+
+        try {
+            BackupToAAD-BitLockerKeyProtector -MountPoint $BitlockerDrive -KeyProtectorId $Key #-ErrorAction SilentlyContinue
+            Write-Output "Attempted to escrow key in Azure AD - Please verify manually!"
+            
+        } catch {
+            Write-Error "This should never have happend? Debug me!"
+            exit 1
+        }
+
     }
+    exit 0
 }
 
 #endregion functions


### PR DESCRIPTION
I was finding that the script would enumerate more than one $KeyProtectorId and then fail to write to Entra ID (BackupToAAD-...) as the value was an array and not a single GUID.

This update loops for each $KeyProtectorId and writes each one to Entra ID. Failing script if any one of the attempts fails. Script succeeds if ALL keys are uploaded